### PR TITLE
Allow setting custom cache path and file prefix

### DIFF
--- a/aio_overpass/query.py
+++ b/aio_overpass/query.py
@@ -673,7 +673,11 @@ class DefaultQueryRunner(QueryRunner):
     )
 
     def __init__(
-        self, max_tries: int = 5, cache_ttl_secs: int = 0, cache_path: Optional[str] = None, cache_file_prefix: str = ""
+        self,
+        max_tries: int = 5,
+        cache_ttl_secs: int = 0,
+        cache_path: Optional[str] = None,
+        cache_file_prefix: str = "",
     ) -> None:
         if max_tries < 1:
             msg = "max_tries must be >= 1"
@@ -809,14 +813,18 @@ def _fibo_backoff_secs(tries: int) -> float:
     return a
 
 
-def __cache_delete(query: Query, *, cache_path: Optional[str] = None, cache_file_prefix: str = "") -> None:
+def __cache_delete(
+    query: Query, *, cache_path: Optional[str] = None, cache_file_prefix: str = ""
+) -> None:
     """Clear a response cached by the default runner (only to be used in tests)."""
     file_name = f"{cache_file_prefix}{query.cache_key}.json"
     file_path = Path(cache_path or tempfile.gettempdir()) / file_name
     file_path.unlink(missing_ok=True)
 
 
-def __cache_expire(query: Query, *, cache_path: Optional[str] = None, cache_file_prefix: str = "") -> None:
+def __cache_expire(
+    query: Query, *, cache_path: Optional[str] = None, cache_file_prefix: str = ""
+) -> None:
     """Clear a response cached by the default runner (only to be used in tests)."""
     file_name = f"{cache_file_prefix}{query.cache_key}.json"
     file_path = Path(cache_path or tempfile.gettempdir()) / file_name

--- a/test/test_default_query_runner.py
+++ b/test/test_default_query_runner.py
@@ -67,20 +67,20 @@ async def test_caching_with_custom_path(mock_response):
         status=200,
     )
 
-    c = Client(runner=VerifyingQueryRunner(cache_ttl_secs=100, cache_path="/tmp/overpass_cache"))
+    c = Client(runner=VerifyingQueryRunner(cache_ttl_secs=100, cache_path="/tmp/overpass_cache", cache_file_prefix="foo-"))
 
     q1 = Query(input_code="nonsense")
     q2 = Query(input_code="nonsense")
     assert q1.cache_key == q2.cache_key
 
-    __cache_delete(q1, cache_path="/tmp/overpass_cache")
+    __cache_delete(q1, cache_path="/tmp/overpass_cache", cache_file_prefix="foo-")
 
     await c.run_query(q1)
     del q1.response[_EXPIRATION_KEY]
     assert q1.response == response
     assert not q1.was_cached
 
-    assert os.path.exists(f"/tmp/overpass_cache/{q1.cache_key}.json")
+    assert os.path.exists(f"/tmp/overpass_cache/foo-{q1.cache_key}.json")
 
     mock_response.post(
         url=URL_INTERPRETER,

--- a/test/test_default_query_runner.py
+++ b/test/test_default_query_runner.py
@@ -1,13 +1,13 @@
 import json
-from pathlib import Path
+import os
 import shutil
+from pathlib import Path
 
 from aio_overpass import Client, Query
 from aio_overpass.query import _EXPIRATION_KEY, __cache_delete, __cache_expire, _fibo_backoff_secs
 from test.util import URL_INTERPRETER, VerifyingQueryRunner, mock_response
 
 import pytest
-import os
 
 
 @pytest.mark.asyncio

--- a/test/test_default_query_runner.py
+++ b/test/test_default_query_runner.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+import shutil
 
 from aio_overpass import Client, Query
 from aio_overpass.query import _EXPIRATION_KEY, __cache_delete, __cache_expire, _fibo_backoff_secs
@@ -67,7 +68,13 @@ async def test_caching_with_custom_path(mock_response):
         status=200,
     )
 
-    c = Client(runner=VerifyingQueryRunner(cache_ttl_secs=100, cache_path="/tmp/overpass_cache", cache_file_prefix="foo-"))
+    shutil.rmtree("/tmp/overpass_cache", ignore_errors=True)
+
+    c = Client(
+        runner=VerifyingQueryRunner(
+            cache_ttl_secs=100, cache_path="/tmp/overpass_cache", cache_file_prefix="foo-"
+        )
+    )
 
     q1 = Query(input_code="nonsense")
     q2 = Query(input_code="nonsense")


### PR DESCRIPTION
I have a use case where I need to have the query cache in a specific directory. This adds an option to `DefaultQueryRunner` called `cache_path`, allowing exactly this.