### PR TITLE
Fixes Unicode Decode Error

### DIFF
--- a/aio_overpass/__init__.py
+++ b/aio_overpass/__init__.py
@@ -40,4 +40,4 @@ from .query import Query
 # extend the module's docstring
 for filename in ("usage.md", "extras.md", "coordinates.md"):
     __doc__ += "\n<br>\n"
-    __doc__ += (Path(__file__).parent / "doc" / filename).read_text()
+    __doc__ += (Path(__file__).parent / "doc" / filename).read_text(encoding="utf-8")


### PR DESCRIPTION
### Summary
This PR fixes a platform-specific `UnicodeDecodeError` in `__init__.py` on Windows by explicitly setting `encoding="utf-8"` in calls to `pathlib.Path.read_text()`. This ensures safe reading of documentation files (e.g., from `doc/`) regardless of the system's locale encoding (e.g., cp1250 failing on byte 0x88).

### Changes
- In `__init__.py`: Added `encoding="utf-8"` to all `read_text()` invocations for doc files.
- No other code changes; the docstring appending functionality is preserved.

### Testing
- Tested on Windows 10 with Python 3.12.7: Import now succeeds without errors.
- Tested on Linux (Ubuntu) with Python 3.12: No regressions.
- Reproduction: See linked issue.

### Related
- Closes #18 


If this needs adjustments (e.g., tests or more changes), let me know!